### PR TITLE
Fix Lambda Name Check

### DIFF
--- a/maestro/actions/update_config.py
+++ b/maestro/actions/update_config.py
@@ -84,3 +84,6 @@ def update_config_action(name, handler, description, timeout, mem_size, runtime,
             putFunctionConcurrency(functionName=name)
 
         print('Function configuration update complete!')
+    else:
+        print('Lambda "%s" not found!' % name)
+        sys.exit(1)

--- a/maestro/providers/aws/check_existence.py
+++ b/maestro/providers/aws/check_existence.py
@@ -21,6 +21,7 @@ class color:
     UNDERLINE = '\033[4m'
     END = '\033[0m'
 
+
 def check(lambda_name):
     '''
     Checks to see if the lambda exists already, if it does, the user will be prompted to use 'update-code' action
@@ -29,24 +30,14 @@ def check(lambda_name):
         lambda_name: name of the lambda, retrieved from config file
     '''
     try:
-        existing_functions = client.list_functions()
-
-        parse = json.dumps(existing_functions)
-        load = json.loads(parse) 
-        functions = load["Functions"]
-
-        current_functions = []
-
-        for function in functions:
-            names = function['FunctionName']
-            append = current_functions.append(names)
-
-        if lambda_name in current_functions:
+        function = client.get_function(FunctionName=lambda_name)
+        if len(function) > 0:
             return True
         else:
             return False
     except ClientError as error:
         print(error.response)
+
 
 def check_alias(lambda_name, alias):
     '''


### PR DESCRIPTION
This branch fixes 2 things 
- The `check_existence::check(lambda_name)` function was using boto3 lambda `list_functions()` call. This only returns the first 50 lambdas. This call was replaced with the more direct get_function(FunctionName) call.
 - The update_config action would check for the lambda name with `check(name)`, but if false was returned, no error occurred and the action would fail silently.